### PR TITLE
Fix entering conferences with unread but deleted texts.

### DIFF
--- a/httpkom/kom.py
+++ b/httpkom/kom.py
@@ -2676,7 +2676,7 @@ class CachedUserConnection(CachedConnection):
         while more_to_fetch:
             try:
                 mapping = ReqLocalToGlobal(self, conf_no, last, 255).response()
-                unread.extend([e[1] for e in mapping.list])
+                unread.extend([e[1] for e in mapping.list if e[1] != 0])
                 last = mapping.range_end
                 more_to_fetch = mapping.later_texts_exists
             except NoSuchLocalText:


### PR DESCRIPTION
If we get 0 as a global text number when mapping locals to globals we
simply ignore it.

This used to cause a server error when for example trying to read the
last 5000 texts in LysKOM conference 7558.
